### PR TITLE
fix: slash some path for windows

### DIFF
--- a/src/core/RoutesFolderWatcher.ts
+++ b/src/core/RoutesFolderWatcher.ts
@@ -33,6 +33,7 @@ export class RoutesFolderWatcher {
     handler: (context: HandlerContext) => void
   ) {
     this.watcher.on(event, (filePath) => {
+      // ensure consistent path for Windows and Unix
       filePath = normalize(filePath)
       // skip other extensions
       if (

--- a/src/core/RoutesFolderWatcher.ts
+++ b/src/core/RoutesFolderWatcher.ts
@@ -33,6 +33,7 @@ export class RoutesFolderWatcher {
     handler: (context: HandlerContext) => void
   ) {
     this.watcher.on(event, (filePath) => {
+      filePath = normalize(filePath)
       // skip other extensions
       if (
         this.options.extensions.every(
@@ -42,7 +43,7 @@ export class RoutesFolderWatcher {
         return
       }
       handler({
-        filePath: normalize(filePath),
+        filePath,
         routePath: this.asRoutePath(filePath),
       })
     })

--- a/src/core/RoutesFolderWatcher.ts
+++ b/src/core/RoutesFolderWatcher.ts
@@ -1,4 +1,5 @@
 import chokidar from 'chokidar'
+import { normalize } from 'pathe'
 import { ResolvedOptions, RoutesFolderOption } from '../options'
 
 export class RoutesFolderWatcher {
@@ -41,7 +42,7 @@ export class RoutesFolderWatcher {
         return
       }
       handler({
-        filePath,
+        filePath: normalize(filePath),
         routePath: this.asRoutePath(filePath),
       })
     })

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -6,7 +6,7 @@ import { generateRouteNamedMap } from '../codegen/generateRouteMap'
 import { MODULE_ROUTES_PATH, MODULE_VUE_ROUTER } from './moduleConstants'
 import { generateRouteRecord } from '../codegen/generateRouteRecords'
 import fg from 'fast-glob'
-import { resolve } from 'pathe'
+import { resolve, normalize as slash } from 'pathe'
 import { ServerContext } from '../options'
 import { getRouteBlock } from './customBlock'
 import { RoutesFolderWatcher, HandlerContext } from './RoutesFolderWatcher'
@@ -93,6 +93,7 @@ export function createRoutesContext(options: ResolvedOptions) {
   }
 
   async function addPage({ filePath: path, routePath }: HandlerContext) {
+    path = slash(path)
     const routeBlock = await getRouteBlock(path, options)
     log(`added "${routePath}" for "${path}"`)
     if (routeBlock) log(routeBlock)
@@ -110,6 +111,7 @@ export function createRoutesContext(options: ResolvedOptions) {
   }
 
   async function updatePage({ filePath: path, routePath }: HandlerContext) {
+    path = slash(path)
     log(`updated "${routePath}" for "${path}"`)
     const node = routeMap.get(path)
     if (!node) {
@@ -122,6 +124,7 @@ export function createRoutesContext(options: ResolvedOptions) {
   }
 
   function removePage({ filePath: path, routePath }: HandlerContext) {
+    path = slash(path)
     log(`remove "${routePath}" for "${path}"`)
     routeTree.remove(routePath)
     routeMap.delete(path)

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -6,7 +6,7 @@ import { generateRouteNamedMap } from '../codegen/generateRouteMap'
 import { MODULE_ROUTES_PATH, MODULE_VUE_ROUTER } from './moduleConstants'
 import { generateRouteRecord } from '../codegen/generateRouteRecords'
 import fg from 'fast-glob'
-import { resolve, normalize as slash } from 'pathe'
+import { resolve } from 'pathe'
 import { ServerContext } from '../options'
 import { getRouteBlock } from './customBlock'
 import { RoutesFolderWatcher, HandlerContext } from './RoutesFolderWatcher'
@@ -93,7 +93,6 @@ export function createRoutesContext(options: ResolvedOptions) {
   }
 
   async function addPage({ filePath: path, routePath }: HandlerContext) {
-    path = slash(path)
     const routeBlock = await getRouteBlock(path, options)
     log(`added "${routePath}" for "${path}"`)
     if (routeBlock) log(routeBlock)
@@ -111,7 +110,6 @@ export function createRoutesContext(options: ResolvedOptions) {
   }
 
   async function updatePage({ filePath: path, routePath }: HandlerContext) {
-    path = slash(path)
     log(`updated "${routePath}" for "${path}"`)
     const node = routeMap.get(path)
     if (!node) {
@@ -124,7 +122,6 @@ export function createRoutesContext(options: ResolvedOptions) {
   }
 
   function removePage({ filePath: path, routePath }: HandlerContext) {
-    path = slash(path)
     log(`remove "${routePath}" for "${path}"`)
     routeTree.remove(routePath)
     routeMap.delete(path)


### PR DESCRIPTION
The first time we add a path, we use "resolve" of "pathe", which will "slash" the path。
![image](https://user-images.githubusercontent.com/36569518/183845807-c359fd72-a3b0-476c-a8b2-6b1a7d2a4886.png)

However, when the page is updated later, the "slash" is not used, which will cause the problem of update loss in windows.
