### PR TITLE
chore: file path handling in playground vite config (#154) [skip ci]

### DIFF
--- a/playground/typed-router.d.ts
+++ b/playground/typed-router.d.ts
@@ -68,7 +68,6 @@ declare module 'vue-router/auto/routes' {
     '/users/[id]': RouteRecordInfo<'/users/[id]', '/users/:id', { id: ParamValue<true> }, { id: ParamValue<false> }>,
     '/users/[id].edit': RouteRecordInfo<'/users/[id].edit', '/users/:id/edit', { id: ParamValue<true> }, { id: ParamValue<false> }>,
     '/users/nested.route.deep': RouteRecordInfo<'/users/nested.route.deep', '/users/nested/route/deep', Record<never, never>, Record<never, never>>,
-    '/vuefire-tests/get-doc': RouteRecordInfo<'/vuefire-tests/get-doc', '/vuefire-tests/get-doc', Record<never, never>, Record<never, never>>,
     '/with-extension': RouteRecordInfo<'/with-extension', '/with-extension', Record<never, never>, Record<never, never>>,
   }
 }

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath, URL } from 'url'
 import { defineConfig } from 'vite'
+import { join } from 'pathe'
 import Inspect from 'vite-plugin-inspect'
 import Markdown from 'vite-plugin-vue-markdown'
 // @ts-ignore: the plugin should not be checked in the playground
@@ -69,7 +70,7 @@ export default defineConfig({
       beforeWriteFiles(root) {
         root.insert(
           '/from-root',
-          '/Users/posva/unplugin-vue-router/playground/src/pages/index.vue'
+          join(__dirname, './src/pages/index.vue')
         )
       },
       routesFolder: [


### PR DESCRIPTION
run `pnpm run play` got this error. 
![image](https://user-images.githubusercontent.com/11146494/233901140-f826a62d-dcc6-4983-b992-e6175d2fb694.png)
