### PR TITLE
fix(codegen): fix broken HMR when importMode is 'sync'

### DIFF
--- a/src/codegen/generateRouteRecords.ts
+++ b/src/codegen/generateRouteRecords.ts
@@ -131,7 +131,7 @@ function generatePageImport(
   } else {
     const importName = `_page_${importsMap.size}`
     importsMap.addDefault(filepath, importName)
-    return importName
+    return `() => Promise.resolve(${importName})`
   }
 }
 


### PR DESCRIPTION
See #132 for context

HMR breaks when using importMode = 'sync'

This PR fools vue-router that the sync component is lazy-loaded by using Promise.resolve, which seems to fix the problem.