### PR TITLE
fix: make compatible with yarn berry

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ After installing, **you should run your dev server** (usually `npm run dev`) **t
 ```diff
 -import { createRouter, createWebHistory } from 'vue-router'
 +import { createRouter, createWebHistory } from 'vue-router/auto'
-
+// with yarn version berry
++import { createRouter, createWebHistory } from 'vue-router-auto'
 createRouter({
   history: createWebHistory(),
   // You don't need to pass the routes anymore,

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ After installing, **you should run your dev server** (usually `npm run dev`) **t
 ```diff
 -import { createRouter, createWebHistory } from 'vue-router'
 +import { createRouter, createWebHistory } from 'vue-router/auto'
+
 // with yarn version berry
 +import { createRouter, createWebHistory } from 'vue-router-auto'
 createRouter({


### PR DESCRIPTION
The example import statement does not work with yarn berry. The following change to the import allows yarn to run the _dev_ script (see included screen recording).
```diff 
-import { createRouter, createWebHistory } from 'vue-router/auto'
+import { createRouter, createWebHistory } from 'vue-router-auto'
```
Yarn Berry Import Statement Screen Recording

https://github.com/posva/unplugin-vue-router/assets/50812322/15dadb16-d43e-4872-abdf-1d28b408273c

