### PR TITLE
Make the index default case insensitive

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -182,8 +182,8 @@ export function getFileBasedRouteName(node: TreeNode): string {
   if (!node.parent) return ''
   return (
     getFileBasedRouteName(node.parent) +
-    '/' +
-    (node.value.rawSegment === 'index' ? '' : node.value.rawSegment)
+    '/' + 
+    (node.value.rawSegment.localeCompare('index', 'en', { sensitivity: 'base' }) ? '' : node.value.rawSegment)
   )
 }
 


### PR DESCRIPTION
Sorry, maybe a bit out of the blue, but I think files named "Index" (note the uppercase) should work as a default too.