### PR TITLE
chore(docs): Comment out invalid links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -108,8 +108,8 @@ export default defineConfig({
     },
 
     nav: [
-      { text: 'Guide', link: '/guide/' },
-      { text: 'API', link: '/api/', activeMatch: '^/api/' },
+      // { text: 'Guide', link: '/guide/' },
+      // { text: 'API', link: '/api/', activeMatch: '^/api/' },
       {
         text: `v${version}`,
         items: [


### PR DESCRIPTION
I'm not sure if the two links in the `nav` are invalid or if the document is still being written, but I've commented them out for now