### PR TITLE
feat: add an option to disable file watching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,7 @@ export default createUnplugin<Options | undefined>((opt = {}, _meta) => {
     },
 
     buildStart() {
-      // TODO: how do we properly check if we are in dev mode?
-      return ctx.scanPages(true)
+      return ctx.scanPages(options.watch)
     },
 
     buildEnd() {

--- a/src/options.ts
+++ b/src/options.ts
@@ -182,10 +182,9 @@ export interface ResolvedOptions {
   /**
    * Whether to watch the files for changes.
    *
-   * Defaults to `true` unless any of the following conditions are met:
-   *
-   * - `CI` environment variable is set
-   * - `NODE_ENV` environment variable is set to `production` or `test`
+   * Defaults to `true` unless the `CI` environment variable is set.
+   * 
+   * @default `!process.env.CI`
    */
   watch: boolean
 }
@@ -220,10 +219,7 @@ export const DEFAULT_OPTIONS: ResolvedOptions = {
   pathParser: {
     dotNesting: true,
   },
-  watch:
-    !process.env.CI &&
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test',
+  watch: !process.env.CI,
 }
 
 export interface ServerContext {

--- a/src/options.ts
+++ b/src/options.ts
@@ -178,6 +178,16 @@ export interface ResolvedOptions {
    * @inheritDoc ParseSegmentOptions
    */
   pathParser: ParseSegmentOptions
+
+  /**
+   * Whether to watch the files for changes.
+   *
+   * Defaults to `true` unless any of the following conditions are met:
+   *
+   * - `CI` environment variable is set
+   * - `NODE_ENV` environment variable is set to `production` or `test`
+   */
+  watch: boolean
 }
 
 /**
@@ -210,6 +220,10 @@ export const DEFAULT_OPTIONS: ResolvedOptions = {
   pathParser: {
     dotNesting: true,
   },
+  watch:
+    !process.env.CI &&
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test',
 }
 
 export interface ServerContext {


### PR DESCRIPTION
Closes #336.

By default file watching is disabled based on certain de facto standard environment variables. I only use vite, so I don't know how other bundlers are affected by this change.

