### PR TITLE
feat: add api for preloading route loaders

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -42,6 +42,7 @@ declare module 'vue-router/auto' {
     // Experimental Data Fetching
     definePage,
     DataLoaderPlugin,
+    preloadRoute,
     NavigationResult,
   } from 'unplugin-vue-router/runtime'
   // must be added to the virtual vue-router/auto

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -7,6 +7,7 @@ import type {
 } from 'vue-router'
 import { ref } from 'vue'
 import { routes } from 'vue-router/auto-routes'
+import { preloadRoute } from 'unplugin-vue-router/runtime'
 
 console.log(`We have ${routes.length} routes.`)
 
@@ -105,6 +106,12 @@ function _test() {
           <input type="text" v-model="targetRoute" />
         </label>
         <button>Go</button>
+        <button
+          type="button"
+          @click.prevent="preloadRoute(router, targetRoute)"
+        >
+          Preload
+        </button>
       </form>
     </div>
   </header>

--- a/playground/src/pages/[name].vue
+++ b/playground/src/pages/[name].vue
@@ -5,6 +5,7 @@ export const useUserData = defineBasicLoader(
   '/[name]',
   async (route) => {
     await delay(1000)
+    console.log('useUserData called for', route.params.name)
     if (route.name === '/[name]') {
       route.params
     }

--- a/src/codegen/vueRouterModule.ts
+++ b/src/codegen/vueRouterModule.ts
@@ -16,6 +16,7 @@ export { definePage } from 'unplugin-vue-router/runtime'
 export {
   DataLoaderPlugin,
   NavigationResult,
+  preloadRoute,
 } from 'unplugin-vue-router/data-loaders'
 
 export * from 'unplugin-vue-router/data-loaders/basic'

--- a/src/data-loaders/entries/index.ts
+++ b/src/data-loaders/entries/index.ts
@@ -1,6 +1,7 @@
 export {
   DataLoaderPlugin,
   NavigationResult,
+  preloadRoute,
   withLoaderContext,
 } from 'unplugin-vue-router/runtime'
 export type {

--- a/src/data-loaders/index.ts
+++ b/src/data-loaders/index.ts
@@ -10,7 +10,11 @@ export type {
 } from './createDataLoader'
 
 // new data fetching
-export { DataLoaderPlugin, NavigationResult } from './navigation-guard'
+export {
+  DataLoaderPlugin,
+  NavigationResult,
+  preloadRoute,
+} from './navigation-guard'
 export type {
   DataLoaderPluginOptions,
   SetupLoaderGuardOptions,


### PR DESCRIPTION
This stems from [the discussion on enabling preloading of data loaders](https://github.com/posva/unplugin-vue-router/discussions/433).

This is just the start of the approach and could mostly be complete nonsense! I just wanted to make sure I pushed where I'd got to so far before Monday in case you investigate this on your stream at all.

I've done some of the steps we discussed, specifically:

1. Extract the required core logic of those beforeEach and beforeResolve guards into exported reusable functions
2. Export a preloadData function somewhere pulling this all together for users to import and use

I don't know the actual location you'd want some of this stuff to live, I just wanted to get a proof of concept up and running first. If you visit the playground, you'll now see a 'preload' button in addition to 'go' button in the 'Navigate to' form. Clicking this will run what we have so far. A `[name]` route is where I've been playing with it so far. I can help adding tests later once I understand things more. This was just the easiest way for me to start playing and understanding.

At the moment, it does seemingly run the correct loader with the the correct route, but it still affects the `isLoading` status of the active loader on the current page if you're already on a `[name]` route.

I'm still in the very early days of understanding all the internals at play as someone who's just come from userland. I might need some assistance moving forward!