### PR TITLE
fix(docs): introduction.md url typo

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -267,7 +267,7 @@ Check the [file-based routing](/guide/file-based-routing) guide for more informa
 
 ### Manipulating the routes
 
-You can pass the `routes` to any plugin that needs to add changes to them but note that **these changes will not be reflected in types**. Use [build-time routes instead](./guide//extending-routes.md) if you want to have types support. Here is an example with [Vitesse starter](https://github.com/antfu/vitesse/blob/main/src/main.ts):
+You can pass the `routes` to any plugin that needs to add changes to them but note that **these changes will not be reflected in types**. Use [build-time routes instead](./guide/extending-routes.md) if you want to have types support. Here is an example with [Vitesse starter](https://github.com/antfu/vitesse/blob/main/src/main.ts):
 
 ```ts
 import { ViteSSG } from 'vite-ssg'


### PR DESCRIPTION

<img width="1331" alt="image" src="https://github.com/posva/unplugin-vue-router/assets/74138412/97a702a3-ac54-453f-900b-69019db2dc66">
When I clicked the link highlighted in the image above, it redirected to a 404 page.
<img width="1032" alt="image" src="https://github.com/posva/unplugin-vue-router/assets/74138412/574b8a88-5695-4078-83f9-39827e22afaf">

