### PR TITLE
refactor(loaders): make data always possibly undefined

### DIFF
--- a/src/data-loaders/defineLoader.spec.ts
+++ b/src/data-loaders/defineLoader.spec.ts
@@ -33,7 +33,7 @@ import { RouteLocationNormalizedLoaded } from 'vue-router'
 
 function mockedLoader<T = string | NavigationResult>(
   // boolean is easier to handle for router mock
-  options?: DefineDataLoaderOptions<boolean>
+  options?: DefineDataLoaderOptions
 ) {
   const [spy, resolve, reject] = mockPromise<T, unknown>(
     // not correct as T could be something else

--- a/src/data-loaders/index.ts
+++ b/src/data-loaders/index.ts
@@ -6,7 +6,6 @@ export type {
   DataLoaderEntryBase,
   DefineDataLoaderOptionsBase,
   DefineLoaderFn,
-  _DataMaybeLazy,
 } from './createDataLoader'
 
 // new data fetching

--- a/src/data-loaders/meta-extensions.ts
+++ b/src/data-loaders/meta-extensions.ts
@@ -16,10 +16,8 @@ import { type NavigationResult } from './navigation-guard'
  * @internal
  */
 export type _DefineLoaderEntryMap<
-  DataLoaderEntry extends DataLoaderEntryBase<
-    boolean,
-    unknown
-  > = DataLoaderEntryBase<boolean, unknown>,
+  DataLoaderEntry extends
+    DataLoaderEntryBase<unknown> = DataLoaderEntryBase<unknown>,
 > = WeakMap<
   // Depending on the `defineLoader()` they might use a different thing as key
   // e.g. an function for basic defineLoader, a doc instance for VueFire

--- a/src/data-loaders/navigation-guard.spec.ts
+++ b/src/data-loaders/navigation-guard.spec.ts
@@ -30,7 +30,7 @@ import type { NavigationFailure } from 'vue-router'
 
 function mockedLoader<T = string | NavigationResult>(
   // boolean is easier to handle for router mock
-  options?: DefineDataLoaderOptions<boolean>
+  options?: DefineDataLoaderOptions
 ) {
   const [spy, resolve, reject] = mockPromise<T, unknown>(
     // not correct as T could be something else

--- a/tests/data-loaders/tester.ts
+++ b/tests/data-loaders/tester.ts
@@ -29,7 +29,7 @@ export function testDefineLoader<Context = void>(
         to: RouteLocationNormalizedLoaded,
         context: DataLoaderContextBase
       ) => Promise<unknown>
-    } & DefineDataLoaderOptionsBase<boolean> & { key?: string }
+    } & DefineDataLoaderOptionsBase & { key?: string }
   ) => UseDataLoader,
   {
     plugins,
@@ -45,7 +45,7 @@ export function testDefineLoader<Context = void>(
 
   function mockedLoader<T = string | NavigationResult>(
     // boolean is easier to handle for router mock
-    options?: DefineDataLoaderOptionsBase<boolean> & { key?: string }
+    options?: DefineDataLoaderOptionsBase & { key?: string }
   ) {
     const [spy, resolve, reject] = mockPromise<T, unknown>(
       // not correct as T could be something else


### PR DESCRIPTION
BREAKING CHANGE: In practice, wrong usage of the data loaders can lead to undefined data even when lazy is false

Close #319

With the introduction of errors, `data` can actually be undefined in many cases. This is overall more correct and produce less complicated types