### PR TITLE
feat: mkdir if parent dir does not exists

### DIFF
--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -14,7 +14,7 @@ describe('e2e routes', () => {
   it('generates the routes', async () => {
     const context = createRoutesContext(
       resolveOptions({
-        // dts: join(__dirname, './__types.d.ts'),
+        // dts: join(__dirname, './.types/__types.d.ts'),
         dts: false,
         logs: false,
         watch: false,

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -6,7 +6,7 @@ import { generateRouteNamedMap } from '../codegen/generateRouteMap'
 import { MODULE_ROUTES_PATH, MODULE_VUE_ROUTER_AUTO } from './moduleConstants'
 import { generateRouteRecord } from '../codegen/generateRouteRecords'
 import fg from 'fast-glob'
-import { relative, resolve } from 'pathe'
+import { dirname, relative, resolve } from 'pathe'
 import { ServerContext } from '../options'
 import { getRouteBlock } from './customBlock'
 import {
@@ -252,6 +252,7 @@ if (import.meta.hot) {
     if (dts) {
       const content = generateDTS()
       if (lastDTS !== content) {
+        await fs.mkdir(dirname(dts), { recursive: true })
         await fs.writeFile(dts, content, 'utf-8')
         logger.timeLog('writeConfigFiles', 'wrote dts file')
         lastDTS = content


### PR DESCRIPTION
Resolve: #515 

- Use `fs.mkdir` with `recursive` before write dts content to the target file
- Add `dts` string options to e2e test file