### PR TITLE
fix: empty chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,92 +32,50 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": {
-        "require": "./dist/index.d.cts",
-        "import": "./dist/index.d.ts"
-      },
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./vite": {
-      "types": {
-        "require": "./dist/vite.d.cts",
-        "import": "./dist/vite.d.ts"
-      },
-      "require": "./dist/vite.cjs",
-      "import": "./dist/vite.js"
+      "import": "./dist/vite.js",
+      "require": "./dist/vite.cjs"
     },
     "./webpack": {
-      "types": {
-        "require": "./dist/webpack.d.cts",
-        "import": "./dist/webpack.d.ts"
-      },
-      "require": "./dist/webpack.cjs",
-      "import": "./dist/webpack.js"
+      "import": "./dist/webpack.js",
+      "require": "./dist/webpack.cjs"
     },
     "./rollup": {
-      "types": {
-        "require": "./dist/rollup.d.cts",
-        "import": "./dist/rollup.d.ts"
-      },
-      "require": "./dist/rollup.cjs",
-      "import": "./dist/rollup.js"
+      "import": "./dist/rollup.js",
+      "require": "./dist/rollup.cjs"
     },
     "./esbuild": {
-      "types": {
-        "require": "./dist/esbuild.d.cts",
-        "import": "./dist/esbuild.d.ts"
-      },
-      "require": "./dist/esbuild.cjs",
-      "import": "./dist/esbuild.js"
+      "import": "./dist/esbuild.js",
+      "require": "./dist/esbuild.cjs"
     },
     "./options": {
-      "types": {
-        "require": "./dist/options.d.cts",
-        "import": "./dist/options.d.ts"
-      },
-      "require": "./dist/options.cjs",
-      "import": "./dist/options.js"
+      "import": "./dist/options.js",
+      "require": "./dist/options.cjs"
     },
     "./runtime": {
-      "types": {
-        "require": "./dist/runtime.d.cts",
-        "import": "./dist/runtime.d.ts"
-      },
-      "require": "./dist/runtime.cjs",
-      "import": "./dist/runtime.js"
+      "import": "./dist/runtime.js",
+      "require": "./dist/runtime.cjs"
     },
     "./types": {
       "types": {
-        "require": "./dist/types.d.cts",
-        "import": "./dist/types.d.ts"
-      },
-      "require": "./dist/types.cjs",
-      "import": "./dist/types.js"
+        "import": "./dist/types.d.ts",
+        "require": "./dist/types.d.cts"
+      }
     },
     "./data-loaders": {
-      "types": {
-        "require": "./dist/data-loaders/index.d.cts",
-        "import": "./dist/data-loaders/index.d.ts"
-      },
-      "require": "./dist/data-loaders/index.cjs",
-      "import": "./dist/data-loaders/index.js"
+      "import": "./dist/data-loaders/index.js",
+      "require": "./dist/data-loaders/index.cjs"
     },
     "./data-loaders/basic": {
-      "types": {
-        "require": "./dist/data-loaders/basic.d.cts",
-        "import": "./dist/data-loaders/basic.d.ts"
-      },
-      "require": "./dist/data-loaders/basic.cjs",
-      "import": "./dist/data-loaders/basic.js"
+      "import": "./dist/data-loaders/basic.js",
+      "require": "./dist/data-loaders/basic.cjs"
     },
     "./data-loaders/pinia-colada": {
-      "types": {
-        "require": "./dist/data-loaders/pinia-colada.d.cts",
-        "import": "./dist/data-loaders/pinia-colada.d.ts"
-      },
-      "require": "./dist/data-loaders/pinia-colada.cjs",
-      "import": "./dist/data-loaders/pinia-colada.js"
+      "import": "./dist/data-loaders/pinia-colada.js",
+      "require": "./dist/data-loaders/pinia-colada.cjs"
     },
     "./client": {
       "types": "./client.d.ts"
@@ -125,8 +83,14 @@
   },
   "typesVersions": {
     "*": {
-      "./client": [
-        "./client.d.ts"
+      "data-loaders": [
+        "./dist/data-loaders/index.d.ts"
+      ],
+      "data-loaders/basic": [
+        "./dist/data-loaders/basic.d.ts"
+      ],
+      "data-loaders/pinia-colada": [
+        "./dist/data-loaders/pinia-colada.d.ts"
       ],
       "*": [
         "./dist/*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { appendExtensionListToPattern } from './core/utils'
 import { MACRO_DEFINE_PAGE_QUERY } from './core/definePage'
 import { createAutoExportPlugin } from './data-loaders/auto-exports'
 
-export * from './types'
+export type * from './types'
 
 export { DEFAULT_OPTIONS }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,3 @@ export type {
   TreeNodeValueStatic,
 } from './core/treeNodeValue'
 export type { EditableTreeNode } from './core/extendRoutes'
-
-// don't remove this: avoid emit empty chunk
-export {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,5 @@ export type {
   TreeNodeValueStatic,
 } from './core/treeNodeValue'
 export type { EditableTreeNode } from './core/extendRoutes'
+
+export {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,4 +11,5 @@ export type {
 } from './core/treeNodeValue'
 export type { EditableTreeNode } from './core/extendRoutes'
 
+// don't remove this: avoid emit empty chunk
 export {}

--- a/tsup-runtime.config.ts
+++ b/tsup-runtime.config.ts
@@ -4,14 +4,12 @@ import { commonOptions } from './tsup.config'
 export default defineConfig([
   {
     ...commonOptions,
-    clean: false,
     entry: ['./src/runtime.ts'],
     external: [...commonOptions.external, 'unplugin-vue-router/types'],
   },
 
   {
     ...commonOptions,
-    clean: false,
     entry: ['./src/data-loaders/entries/*'],
     // to work with node10 moduleResolution mode
     outDir: 'dist/data-loaders',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,8 @@
+import { rm } from 'node:fs/promises'
 import { defineConfig, type Options } from 'tsup'
 
 export const commonOptions = {
-  clean: true,
+  clean: false,
   format: ['cjs', 'esm'],
   dts: true,
   external: [
@@ -16,17 +17,25 @@ export const commonOptions = {
   splitting: true,
 } satisfies Options
 
-export default defineConfig([
-  {
-    ...commonOptions,
-    entry: [
-      './src/index.ts',
-      './src/options.ts',
-      './src/esbuild.ts',
-      './src/rollup.ts',
-      './src/vite.ts',
-      './src/webpack.ts',
-      './src/types.ts',
-    ],
-  },
-])
+export default defineConfig(async () => {
+  await rm('dist', { recursive: true, force: true })
+
+  return [
+    {
+      ...commonOptions,
+      entry: [
+        './src/index.ts',
+        './src/options.ts',
+        './src/esbuild.ts',
+        './src/rollup.ts',
+        './src/vite.ts',
+        './src/webpack.ts',
+      ],
+    },
+    {
+      ...commonOptions,
+      dts: { only: true },
+      entry: ['./src/types.ts'],
+    },
+  ]
+})


### PR DESCRIPTION
This PR also includes:
- remove types from all subpackage exports (there is no need)
- remove import/require from `./types` subpackage export: should export only types, there is no implementation
- include `data-loaders/*` in `typesVersions`: node10 types broken
- remove `client` from `typesVersions`.

I'm going to check on my local Windows laptop the error with long paths in Nuxt.

We split tsup options to generate only dts for `src/types.ts` (thx for the help @brc-dd)