### PR TITLE
fix: remove empty chunks and simplify package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,92 +32,50 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": {
-        "require": "./dist/index.d.cts",
-        "import": "./dist/index.d.ts"
-      },
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./vite": {
-      "types": {
-        "require": "./dist/vite.d.cts",
-        "import": "./dist/vite.d.ts"
-      },
-      "require": "./dist/vite.cjs",
-      "import": "./dist/vite.js"
+      "import": "./dist/vite.js",
+      "require": "./dist/vite.cjs"
     },
     "./webpack": {
-      "types": {
-        "require": "./dist/webpack.d.cts",
-        "import": "./dist/webpack.d.ts"
-      },
-      "require": "./dist/webpack.cjs",
-      "import": "./dist/webpack.js"
+      "import": "./dist/webpack.js",
+      "require": "./dist/webpack.cjs"
     },
     "./rollup": {
-      "types": {
-        "require": "./dist/rollup.d.cts",
-        "import": "./dist/rollup.d.ts"
-      },
-      "require": "./dist/rollup.cjs",
-      "import": "./dist/rollup.js"
+      "import": "./dist/rollup.js",
+      "require": "./dist/rollup.cjs"
     },
     "./esbuild": {
-      "types": {
-        "require": "./dist/esbuild.d.cts",
-        "import": "./dist/esbuild.d.ts"
-      },
-      "require": "./dist/esbuild.cjs",
-      "import": "./dist/esbuild.js"
+      "import": "./dist/esbuild.js",
+      "require": "./dist/esbuild.cjs"
     },
     "./options": {
-      "types": {
-        "require": "./dist/options.d.cts",
-        "import": "./dist/options.d.ts"
-      },
-      "require": "./dist/options.cjs",
-      "import": "./dist/options.js"
+      "import": "./dist/options.js",
+      "require": "./dist/options.cjs"
     },
     "./runtime": {
-      "types": {
-        "require": "./dist/runtime.d.cts",
-        "import": "./dist/runtime.d.ts"
-      },
-      "require": "./dist/runtime.cjs",
-      "import": "./dist/runtime.js"
+      "import": "./dist/runtime.js",
+      "require": "./dist/runtime.cjs"
     },
     "./types": {
       "types": {
-        "require": "./dist/types.d.cts",
-        "import": "./dist/types.d.ts"
-      },
-      "require": "./dist/types.cjs",
-      "import": "./dist/types.js"
+        "import": "./dist/types.d.ts",
+        "require": "./dist/types.d.cts"
+      }
     },
     "./data-loaders": {
-      "types": {
-        "require": "./dist/data-loaders/index.d.cts",
-        "import": "./dist/data-loaders/index.d.ts"
-      },
-      "require": "./dist/data-loaders/index.cjs",
-      "import": "./dist/data-loaders/index.js"
+      "import": "./dist/data-loaders/index.js",
+      "require": "./dist/data-loaders/index.cjs"
     },
     "./data-loaders/basic": {
-      "types": {
-        "require": "./dist/data-loaders/basic.d.cts",
-        "import": "./dist/data-loaders/basic.d.ts"
-      },
-      "require": "./dist/data-loaders/basic.cjs",
-      "import": "./dist/data-loaders/basic.js"
+      "import": "./dist/data-loaders/basic.js",
+      "require": "./dist/data-loaders/basic.cjs"
     },
     "./data-loaders/pinia-colada": {
-      "types": {
-        "require": "./dist/data-loaders/pinia-colada.d.cts",
-        "import": "./dist/data-loaders/pinia-colada.d.ts"
-      },
-      "require": "./dist/data-loaders/pinia-colada.cjs",
-      "import": "./dist/data-loaders/pinia-colada.js"
+      "import": "./dist/data-loaders/pinia-colada.js",
+      "require": "./dist/data-loaders/pinia-colada.cjs"
     },
     "./client": {
       "types": "./client.d.ts"
@@ -125,8 +83,14 @@
   },
   "typesVersions": {
     "*": {
-      "./client": [
-        "./client.d.ts"
+      "data-loaders": [
+        "./dist/data-loaders/index.d.ts"
+      ],
+      "data-loaders/basic": [
+        "./dist/data-loaders/basic.d.ts"
+      ],
+      "data-loaders/pinia-colada": [
+        "./dist/data-loaders/pinia-colada.d.ts"
       ],
       "*": [
         "./dist/*",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { appendExtensionListToPattern } from './core/utils'
 import { MACRO_DEFINE_PAGE_QUERY } from './core/definePage'
 import { createAutoExportPlugin } from './data-loaders/auto-exports'
 
-export * from './types'
+export type * from './types'
 
 export { DEFAULT_OPTIONS }
 


### PR DESCRIPTION
diff:

```diff
--rw-r--r--@  1 501  20  59557 Jan 21 16:21 chunk-4AWHJGLE.cjs
--rw-r--r--@  1 501  20      0 Jan 21 16:21 chunk-6F4PWJZI.js
 -rw-r--r--@  1 501  20  11377 Jan 21 16:21 chunk-6INN7JET.cjs
--rw-r--r--@  1 501  20  56078 Jan 21 16:21 chunk-AUGILURB.js
 -rw-r--r--@  1 501  20  10087 Jan 21 16:21 chunk-GI4LFDHF.js
--rw-r--r--@  1 501  20     13 Jan 21 16:21 chunk-ZBPRDZS4.cjs
+-rw-r--r--@  1 501  20  59557 Jan 21 16:21 chunk-KUVP6IGQ.cjs
+-rw-r--r--@  1 501  20  56078 Jan 21 16:21 chunk-ST2JE3TR.js
```

x-ref: #566; docs:build is working fine with this