### PR TITLE
chore: switch to tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "@vue-macros/common": "3.0.0-beta.8",
     "ast-walker-scope": "^0.7.1",
     "chokidar": "^4.0.3",
-    "fast-glob": "^3.3.3",
     "json5": "^2.2.3",
     "local-pkg": "^1.1.1",
     "magic-string": "^0.30.17",
@@ -143,9 +142,7 @@
     "pathe": "^2.0.3",
     "picomatch": "^4.0.2",
     "scule": "^1.3.0",
-    "unplugin": "^2.3.2",
-    "unplugin-utils": "^0.2.4",
-    "yaml": "^2.7.1"
+    "tinyglobby": "^0.2.12"
   },
   "peerDependencies": {
     "vue-router": "^4.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -41,15 +38,9 @@ importers:
       scule:
         specifier: ^1.3.0
         version: 1.3.0
-      unplugin:
-        specifier: ^2.3.2
-        version: 2.3.2
-      unplugin-utils:
-        specifier: ^0.2.4
-        version: 0.2.4
-      yaml:
-        specifier: ^2.7.1
-        version: 2.7.1
+      tinyglobby:
+        specifier: ^0.2.12
+        version: 0.2.12
     devDependencies:
       '@babel/types':
         specifier: ^7.27.0

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -5,7 +5,7 @@ import { asRoutePath, ImportsMap, logTree, throttle } from './utils'
 import { generateRouteNamedMap } from '../codegen/generateRouteMap'
 import { MODULE_ROUTES_PATH, MODULE_VUE_ROUTER_AUTO } from './moduleConstants'
 import { generateRouteRecord } from '../codegen/generateRouteRecords'
-import fg from 'fast-glob'
+import { glob } from 'tinyglobby'
 import { dirname, relative, resolve } from 'pathe'
 import { ServerContext } from '../options'
 import { getRouteBlock } from './customBlock'
@@ -73,11 +73,12 @@ export function createRoutesContext(options: ResolvedOptions) {
             f.startsWith('**') ? f : relative(folder.src, f)
           )
 
-          return fg(folder.pattern, {
+          return glob(folder.pattern, {
             cwd: folder.src,
             // TODO: do they return the symbolic link path or the original file?
             // followSymbolicLinks: false,
             ignore: ignorePattern,
+            expandDirectories: false,
           }).then((files) =>
             Promise.all(
               files


### PR DESCRIPTION
https://npmgraph.js.org/?q=fast-glob - 17 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies

vite, vitest, nuxt, and others have already switched