### PR TITLE
chore: adjusted lazy option type

### DIFF
--- a/src/data-loaders/createDataLoader.ts
+++ b/src/data-loaders/createDataLoader.ts
@@ -161,7 +161,7 @@ export interface DefineDataLoaderOptionsBase_LaxData
  */
 export interface DefineDataLoaderOptionsBase_DefinedData
   extends _DefineDataLoaderOptionsBase_Common {
-  lazy?: false
+  lazy?: boolean
   server?: true
   errors?: false
 }


### PR DESCRIPTION
More details at #599.

I want to use a shared object for the options of `defineBasicLoader` with the following options:

```ts
const basicLoaderOptions: DefineDataLoaderOptions_DefinedData = {
    // Make the loader "lazy" on the client so it DOES NOT re-fetch after hydration:
    lazy: () => !import.meta.env.SSR
}
```

## Typescript issue

With the current object `basicLoaderOptions`, Typescript will complaint since the type `DefineDataLoaderOptionsBase_DefinedData.lazy` only accepts `false | undefined`, but not `true`.

The documentation states that this option can also be `true`.

Let me know if I am missing something. Thanks!