### PR TITLE
feat: allow post-processing generated DTS file

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -68,6 +68,11 @@ VueRouter({
   async beforeWriteFiles(rootRoute) {
     // ...
   },
+
+  // modify the generated DTS file before written to disk
+  async postProcessDTS(dts) {
+    // ...
+  },
 })
 ```
 

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createRoutesContext } from '../src/core/context'
 import { resolveOptions } from '../src/options'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 import { normalize, join } from 'pathe'
 
@@ -32,6 +33,23 @@ describe('e2e routes', () => {
         )
         .replace(/(import\(["'])(?:.+?)fixtures\/filenames/gi, '$1')
     ).toMatchSnapshot()
+  })
+
+  it('allows post-processing the generated DTS file', async () => {
+    const suffix = `export type Foo = 'bar'`
+    const dts = join(__dirname, './.types/__types.d.ts')
+    const context = createRoutesContext(
+      resolveOptions({
+        dts,
+        logs: false,
+        watch: false,
+        routesFolder: [{ src: join(__dirname, './fixtures/filenames/routes') }],
+        postProcessDTS: (dts) => `${dts}\n${suffix}\n`,
+      })
+    )
+
+    await context.scanPages()
+    expect(readFileSync(dts, 'utf-8')).toContain(suffix)
   })
 
   it.skip('works with mixed extensions', async () => {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -263,7 +263,12 @@ if (import.meta.hot) {
 
     logTree(routeTree, logger.log)
     if (dts) {
-      const content = generateDTS()
+      let content = generateDTS()
+
+      if (options.postProcessDTS) {
+        content = await options.postProcessDTS(content)
+      }
+
       if (lastDTS !== content) {
         await fs.mkdir(dirname(dts), { recursive: true })
         await fs.writeFile(dts, content, 'utf-8')

--- a/src/options.ts
+++ b/src/options.ts
@@ -164,6 +164,11 @@ export interface Options {
   beforeWriteFiles?: (rootRoute: EditableTreeNode) => _Awaitable<void>
 
   /**
+   * Allows to post-process the generated d.ts files. This will be invoked **every time** the d.ts file needs to be written.
+   */
+  postProcessDTS?: (dts: string) => _Awaitable<string>
+
+  /**
    * Defines how page components should be imported. Defaults to dynamic imports to enable lazy loading of pages.
    * @default `'async'`
    */


### PR DESCRIPTION
This adds a `postProcessDTS` option, which is a sync or async function that receives the generated DTS file's contents and lets that function return a modified string. This allows frameworks to add info of their own on the type-level in the generated DTS file.

An example of how this may be used:
- A framework, such as Nuxt, passes `routesFolder: []` and uses `beforeWriteFiles` to provide their own route tree.
- If the framework wants to store more info about that generated tree in a DTS file, they can now append this info to the generated DTS file. That info might for example contain a Record of file paths mapped to their corresponding route names.

I included an E2E test that tests this functionality. I couldn't figure out whether the E2E tests are actually ran in the CI though? They don't seem to be ran when running `pnpm test`. However, I did run the test manually and it did succeed.