### PR TITLE
feat: allow `filePath` to be `null` on a route added in an editable tree

### DIFF
--- a/src/core/extendRoutes.spec.ts
+++ b/src/core/extendRoutes.spec.ts
@@ -30,6 +30,15 @@ describe('EditableTreeNode', () => {
     expect(tree.children.get('foo')?.path).toBe('/foo')
   })
 
+  it('allows filePath to be null on a route added in the editable tree', () => {
+    const tree = new PrefixTree(RESOLVED_OPTIONS)
+    const editable = new EditableTreeNode(tree)
+
+    editable.insert('foo', null)
+    expect(editable.children).toHaveLength(1)
+    expect(editable.children[0]?.path).toBe('/foo')
+  })
+
   it('keeps nested routes flat', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
     const editable = new EditableTreeNode(tree)

--- a/src/core/extendRoutes.ts
+++ b/src/core/extendRoutes.ts
@@ -38,7 +38,7 @@ export class EditableTreeNode {
    * @param filePath - file path
    * @returns the new editable route node
    */
-  insert(path: string, filePath: string) {
+  insert(path: string, filePath: string | null) {
     // adapt paths as they should match a file system
     let addBackLeadingSlash = false
     if (path.startsWith('/')) {

--- a/src/core/tree.ts
+++ b/src/core/tree.ts
@@ -90,9 +90,9 @@ export class TreeNode {
    * @param path - path segment to insert, already parsed (e.g. users/:id)
    * @param filePath - file path, defaults to path for convenience and testing
    */
-  insertParsedPath(path: string, filePath: string = path): TreeNode {
-    // TODO: allow null filePath?
-    const isComponent = true
+  insertParsedPath(path: string, filePath: string | null = path): TreeNode {
+    // Allow null filePath to be handled
+    const isComponent = filePath !== null
 
     const node = new TreeNode(
       {


### PR DESCRIPTION
It seems that, when we only allow `filePath` to be `null` on a route added in an editable tree, that shouldn't cause any problems.

In Nuxt, we don't use file scanning and add routes by modifying the `EditableTreeNode` of the root page in the `beforeWriteFiles` callback. A `NuxtPage` can theoretically not have a corresponding `file`, although I'm not sure what the use case here is exactly. So currently, where we run `parent.insert(path, page.file)`, `page.file` can be `undefined` and we currently use a `@ts-expect-error` before that line to suppress TS errors.

If this PR is safe to merge, we can remove that `@ts-expect-error`.