### PR TITLE
feat: add auto-hmr-plugin and autoHmr option

### DIFF
--- a/src/auto-hmr/index.ts
+++ b/src/auto-hmr/index.ts
@@ -1,0 +1,101 @@
+import type { UnpluginOptions } from 'unplugin'
+import type { VariableDeclarator, ImportDeclaration } from 'estree'
+
+function nameFromDeclaration(node?: VariableDeclarator) {
+  return node?.id.type === 'Identifier' ? node.id.name : ''
+}
+
+function getRouterDeclaration(nodes?: VariableDeclarator[]) {
+  return nodes?.find(
+    (x) =>
+      x.init?.type === 'CallExpression' &&
+      x.init.callee.type === 'Identifier' &&
+      x.init.callee.name === 'createRouter'
+  )
+}
+
+function getHandleHotUpdateDeclaration(node?: ImportDeclaration, modulePath?: string) {
+  return (
+    node?.type === 'ImportDeclaration' &&
+    node.source.value === modulePath &&
+    node.specifiers.some(
+      (x) =>
+        x.type === 'ImportSpecifier' &&
+        x.imported.type === 'Identifier' &&
+        x.imported.name === 'handleHotUpdate'
+    )
+  )
+}
+
+interface AutoHmrPluginOptions {
+  modulePath: string
+}
+
+export function createAutoHmrPlugin({ modulePath }: AutoHmrPluginOptions): UnpluginOptions {
+  const handleHotUpdateCallRegex = /handleHotUpdate\([\s\S]*?\)/
+
+  return {
+    name: 'unplugin-vue-router-auto-hmr',
+    enforce: 'post',
+
+    transform(code, id) {
+      if (id.startsWith('\x00')) return
+
+      // If you don't use automatically generated routes,
+      // maybe it will be meaningless to deal with hmr?
+      if (!code.includes('createRouter(') && !code.includes(modulePath)) {
+        return
+      }
+
+      const ast = this.parse(code)
+
+      let isImported: boolean = false
+      let routerName: string | undefined
+      let routerDeclaration: VariableDeclarator | undefined
+
+      // @ts-expect-error
+      for (const node of ast.body) {
+        if (
+          node.type === 'ExportNamedDeclaration' ||
+          node.type === 'VariableDeclaration'
+        ) {
+          if (!routerName) {
+            routerDeclaration = getRouterDeclaration(node.type === 'VariableDeclaration'
+              ? node.declarations
+              : node.declaration?.type === 'VariableDeclaration'
+                ? node.declaration?.declarations
+                : undefined)
+
+            routerName = nameFromDeclaration(routerDeclaration)
+          }
+        } else if (node.type === 'ImportDeclaration') {
+          isImported ||= getHandleHotUpdateDeclaration(node, modulePath)
+        }
+      }
+
+      if (routerName) {
+        const isHandleHotUpdateCalled = handleHotUpdateCallRegex.test(code)
+
+        const handleHotUpdateCode = [code]
+
+        // add import if not imported
+        if (!isImported) {
+          handleHotUpdateCode.unshift(
+            `import { handleHotUpdate } from '${modulePath}'`
+          )
+        }
+
+        // add handleHotUpdate call if not called
+        if (!isHandleHotUpdateCalled) {
+          handleHotUpdateCode.push(`handleHotUpdate(${routerName})`)
+        }
+
+        return {
+          code: handleHotUpdateCode.join('\n')
+        }
+      }
+
+      return
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { join } from 'pathe'
 import { appendExtensionListToPattern } from './core/utils'
 import { MACRO_DEFINE_PAGE_QUERY } from './core/definePage'
 import { createAutoExportPlugin } from './data-loaders/auto-exports'
+import { createAutoHmrPlugin } from './auto-hmr'
 
 export type * from './types'
 
@@ -198,6 +199,14 @@ export default createUnplugin<Options | undefined>((opt = {}, _meta) => {
         filterPageComponents,
         loadersPathsGlobs: options.experimental.autoExportsDataLoaders,
         root: options.root,
+      })
+    )
+  }
+
+  if (options.autoHmr) {
+    plugins.push(
+      createAutoHmrPlugin({
+        modulePath: MODULE_ROUTES_PATH,
       })
     )
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -214,6 +214,12 @@ export interface Options {
   watch?: boolean
 
   /**
+   * Whether to enable auto HMR for Vue Router.
+   * @default `false`
+   */
+  autoHmr?: boolean
+
+  /**
    * Experimental options. **Warning**: these can change or be removed at any time, even it patch releases. Keep an eye
    * on the Changelog.
    */


### PR DESCRIPTION
reimpl: https://github.com/posva/unplugin-vue-router/pull/617

This pr is similar to the implementation of https://github.com/vuejs/pinia/pull/2954, which transfers the work of automatically injecting hmr code to the plugin part, and adds an option to control whether the plugin is enabled or not.