### PR TITLE
fix: missing data warning only when both data and error are empty

### DIFF
--- a/src/data-loaders/defineColadaLoader.ts
+++ b/src/data-loaders/defineColadaLoader.ts
@@ -335,7 +335,7 @@ export function defineColadaLoader<Data>(
     if (this.pendingTo === to) {
       // console.log(' ->', this.staged)
       if (process.env.NODE_ENV === 'development') {
-        if (this.staged === STAGED_NO_VALUE) {
+        if (this.staged === STAGED_NO_VALUE && this.stagedError === null) {
           console.warn(
             `Loader "${key}"'s "commit()" was called but there is no staged data.`
           )

--- a/src/data-loaders/defineLoader.ts
+++ b/src/data-loaders/defineLoader.ts
@@ -281,7 +281,7 @@ export function defineBasicLoader<Data>(
     if (this.pendingTo === to) {
       // console.log('👉 commit', this.staged)
       if (process.env.NODE_ENV === 'development') {
-        if (this.staged === STAGED_NO_VALUE) {
+        if (this.staged === STAGED_NO_VALUE && this.stagedError === null) {
           console.warn(
             `Loader "${options.key}"'s "commit()" was called but there is no staged data.`
           )

--- a/src/data-loaders/defineQueryLoader.ts
+++ b/src/data-loaders/defineQueryLoader.ts
@@ -211,7 +211,7 @@ export function defineQueryLoader<Data, isLazy extends boolean>(
     if (this.pendingTo === to && !this.error.value) {
       console.log('👉 commit', this.staged)
       if (process.env.NODE_ENV === 'development') {
-        if (this.staged === STAGED_NO_VALUE) {
+        if (this.staged === STAGED_NO_VALUE && this.stagedError === null) {
           console.warn(
             `Loader "${options.queryKey?.join(
               '/'

--- a/src/data-loaders/defineVueFireLoader.ts
+++ b/src/data-loaders/defineVueFireLoader.ts
@@ -159,7 +159,7 @@ export function defineVueFireLoader<
     if (this.pendingTo === to && !this.error.value) {
       // console.log('👉 commit', this.staged)
       if (process.env.NODE_ENV === 'development') {
-        if (this.staged === STAGED_NO_VALUE) {
+        if (this.staged === STAGED_NO_VALUE && this.stagedError === null) {
           console.warn(
             `Loader "${options.key}"'s "commit()" was called but there is no staged data.`
           )


### PR DESCRIPTION
Closes #675.

Ensures that missing data warning is only logged if both `this.staged` is `STAGED_NO_VALUE` and `this.stagedError` is `null`.
