### PR TITLE
fix: avoid empty param names breaking dts syntax

### DIFF
--- a/src/codegen/generateRouteParams.ts
+++ b/src/codegen/generateRouteParams.ts
@@ -7,7 +7,7 @@ export function generateRouteParams(node: TreeNode, isRaw: boolean): string {
     ? `{ ${nodeParams
         .map(
           (param) =>
-            `${param.paramName}${param.optional ? '?' : ''}: ` +
+            `${param.paramName || `''`}${param.optional ? '?' : ''}: ` +
             (param.modifier === '+'
               ? `ParamValueOneOrMore<${isRaw}>`
               : param.modifier === '*'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route parameter generation to handle missing parameter names by using an empty string key, preventing “undefined” from appearing in generated output.
  * Improves correctness and stability of code-generated routes in edge cases without altering existing behavior for named parameters.
  * No changes to public APIs or types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->