### PR TITLE
chore(volar): add types to volar subpackage exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,12 @@
       "require": "./dist/data-loaders/pinia-colada.cjs"
     },
     "./volar/sfc-route-blocks": {
-      "require": "./dist/volar/sfc-route-blocks.cjs"
+      "types": "./dist/volar/sfc-route-blocks.d.cts",
+      "default": "./dist/volar/sfc-route-blocks.cjs"
     },
     "./volar/sfc-typed-router": {
-      "require": "./dist/volar/sfc-typed-router.cjs"
+      "types": "./dist/volar/sfc-typed-router.d.cts",
+      "default": "./dist/volar/sfc-typed-router.cjs"
     },
     "./client": {
       "types": "./client.d.ts"
@@ -97,6 +99,12 @@
       ],
       "data-loaders/pinia-colada": [
         "./dist/data-loaders/pinia-colada.d.ts"
+      ],
+      "volar/sfc-route-blocks": [
+        "./dist/volar/sfc-route-blocks.d.cts"
+      ],
+      "volar/sfc-typed-router": [
+        "./dist/volar/sfc-typed-router.d.cts"
       ],
       "*": [
         "./dist/*",


### PR DESCRIPTION
Without this PR volar types only for node16 module resolution:
<img width="566" height="222" alt="volar subpackages export types at main branch" src="https://github.com/user-attachments/assets/8e832209-6588-4b7c-af8f-9138caed10f7" />

With this PR, types for any module resolution:
<img width="608" height="237" alt="new volar subpackages export types" src="https://github.com/user-attachments/assets/222adc1b-69af-4b54-82f5-6c697dd30bac" />

