### PR TITLE
test: add rough failing nested aborted loaders test

### DIFF
--- a/tests/data-loaders/tester.ts
+++ b/tests/data-loaders/tester.ts
@@ -1106,7 +1106,6 @@ export function testDefineLoader<Context = void>(
   it(`nested loader correctly aborts top level loader`, async () => {
     const alwaysAbortsLoader = loaderFactory({
       fn: async () => {
-        console.log('BBB')
         const controller = new AbortController()
         controller.abort()
         controller.signal.throwIfAborted()
@@ -1115,8 +1114,6 @@ export function testDefineLoader<Context = void>(
       },
       key: 'nested',
     })
-
-    console.log('HUUUh', alwaysAbortsLoader)
 
     const rootLoader = loaderFactory({
       fn: async () => {


### PR DESCRIPTION
As requested here
https://github.com/posva/unplugin-vue-router/issues/763#issuecomment-3589545289

Sorry for the test quality, I didn't spend much time in putting it all together and I find it difficult to understand how test loaders in there, but I hope it illustrates general issue.

<img width="1005" height="201" alt="image" src="https://github.com/user-attachments/assets/dd71942e-cddc-402c-b69e-246b073bd6fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case for nested loader abort behavior with AbortController.
  * Note: Test case appears duplicated in the file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->