### PR TITLE
feat: custom param name

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -51,6 +51,10 @@ export function createRoutesContext(options: ResolvedOptions) {
     },
   })
 
+  const getParamParserName =
+    options.experimental.paramParsers?.getName ||
+    ((file: string) => parsePathe(file).name)
+
   // populated by the initial scan pages
   const watchers: Array<FSWatcher | RoutesFolderWatcher> = []
   const paramParsersMap: ParamParsersMap = new Map()
@@ -133,10 +137,7 @@ export function createRoutesContext(options: ResolvedOptions) {
           expandDirectories: false,
         }).then((paramParserFiles) => {
           for (const file of paramParserFiles) {
-            const getName =
-              options.experimental.paramParsers?.getName ||
-              ((file: string) => parsePathe(file).name)
-            const name = getName(file)
+            const name = getParamParserName(file)
             // TODO: could be simplified to only one import that starts with / for vite
             const absolutePath = resolve(folder, file)
             paramParsersMap.set(name, {
@@ -221,7 +222,7 @@ export function createRoutesContext(options: ResolvedOptions) {
     logger.log(`🤖 Scanning param parsers in ${cwd}`)
     return watcher
       .on('add', (file) => {
-        const name = parsePathe(file).name
+        const name = getParamParserName(file)
         const absolutePath = resolve(cwd, file)
         paramParsersMap.set(name, {
           name,
@@ -232,7 +233,7 @@ export function createRoutesContext(options: ResolvedOptions) {
         writeConfigFiles()
       })
       .on('unlink', (file) => {
-        paramParsersMap.delete(parsePathe(file).name)
+        paramParsersMap.delete(getParamParserName(file))
         writeConfigFiles()
       })
   }

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -133,8 +133,10 @@ export function createRoutesContext(options: ResolvedOptions) {
           expandDirectories: false,
         }).then((paramParserFiles) => {
           for (const file of paramParserFiles) {
-            const getName = options.experimental.paramParsers?.getName || ((file: string) => parsePathe(file).name);
-            const name = getName(file);
+            const getName =
+              options.experimental.paramParsers?.getName ||
+              ((file: string) => parsePathe(file).name)
+            const name = getName(file)
             // TODO: could be simplified to only one import that starts with / for vite
             const absolutePath = resolve(folder, file)
             paramParsersMap.set(name, {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -133,7 +133,8 @@ export function createRoutesContext(options: ResolvedOptions) {
           expandDirectories: false,
         }).then((paramParserFiles) => {
           for (const file of paramParserFiles) {
-            const name = parsePathe(file).name
+            const getName = options.experimental.paramParsers?.getName || ((file: string) => parsePathe(file).name);
+            const name = getName(file);
             // TODO: could be simplified to only one import that starts with / for vite
             const absolutePath = resolve(folder, file)
             paramParsersMap.set(name, {

--- a/src/options.ts
+++ b/src/options.ts
@@ -243,7 +243,12 @@ export interface ParamParsersOptions {
    * @default `['src/params']`
    */
   dir?: string | string[]
-  getName?: (path: string) => string
+  /**
+   * Method to generate the name of the param matcher.
+   * 
+   * @default `(file) => path.parse(file).name`
+   */
+  getName?: (file: string) => string
 }
 
 export const DEFAULT_PARAM_PARSERS_OPTIONS = {

--- a/src/options.ts
+++ b/src/options.ts
@@ -245,7 +245,7 @@ export interface ParamParsersOptions {
   dir?: string | string[]
   /**
    * Method to generate the name of the param matcher.
-   * 
+   *
    * @default `(file) => path.parse(file).name`
    */
   getName?: (file: string) => string

--- a/src/options.ts
+++ b/src/options.ts
@@ -243,11 +243,13 @@ export interface ParamParsersOptions {
    * @default `['src/params']`
    */
   dir?: string | string[]
+  getName?: (path: string) => string
 }
 
 export const DEFAULT_PARAM_PARSERS_OPTIONS = {
   dir: ['src/params'],
-} satisfies Required<ParamParsersOptions>
+  getName: undefined,
+} satisfies ParamParsersOptions
 
 export const DEFAULT_OPTIONS = {
   extensions: ['.vue'],


### PR DESCRIPTION
I've been giving the param matchers a try and they're absolutely great!

Context for this change: I use kebab case to define my param matchers, but that breaks the types since there can be no dashes in type names. Personally I'd like to use this to convert the name to camel case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parameter parsers now support customizable name generation via configuration, letting you override how parser names are derived while preserving the existing default behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->